### PR TITLE
Update default values.yaml

### DIFF
--- a/metricbeat/values.yaml
+++ b/metricbeat/values.yaml
@@ -244,6 +244,7 @@ clusterRoleRules:
       - namespaces
       - events
       - pods
+      - services
     verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions"]
     resources:
@@ -259,6 +260,10 @@ clusterRoleRules:
     resources:
       - nodes/stats
     verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+    verbs: ["get", "list", "watch"]
 
 podAnnotations: {}
 # iam.amazonaws.com/role: es-cluster


### PR DESCRIPTION
Added `apiGroups: ["batch"]` block and `services` in the `apiGroups: [""]` resources list, to avoid errors like:
```
E1126 13:22:56.085097       6 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.4/tools/cache/reflector.go:156: Failed to watch *v1.Service: failed to list *v1.Service: services is forbidden: User "system:serviceaccount:sole-system:prod-telem-metricbeat" cannot list resource "services" in API group "" at the cluster scope
E1126 13:22:59.958463       6 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.4/tools/cache/reflector.go:156: Failed to watch *v1.Job: failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:sole-system:prod-telem-metricbeat" cannot list resource "jobs" in API group "batch" at the cluster scope
```

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
